### PR TITLE
New Parameters & Removing Mods no longer in ArmA 3 Dir

### DIFF
--- a/MainForm.glade
+++ b/MainForm.glade
@@ -727,9 +727,9 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkCheckButton" id="cbFilePatching">
-                                    <property name="label" translatable="yes">Enable File-Patching</property>
-                                    <property name="name">cbFilePatching</property>
+                                  <object class="GtkCheckButton" id="cbDisableMulticore">
+                                    <property name="label" translatable="yes">Disable Multicore Rendering</property>
+                                    <property name="name">cbDisableMulticore</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
@@ -755,9 +755,9 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkCheckButton" id="cbNoLogs">
-                                    <property name="label" translatable="yes">No Logs</property>
-                                    <property name="name">cbNoLogs</property>
+                                  <object class="GtkCheckButton" id="cbHugePages">
+                                    <property name="label" translatable="yes">Enable Huge Pages</property>
+                                    <property name="name">cbHugePages</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
@@ -780,6 +780,90 @@
                                     <property name="fill">True</property>
                                     <property name="padding">4</property>
                                     <property name="position">13</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="cbFilePatching">
+                                    <property name="label" translatable="yes">Enable File-Patching</property>
+                                    <property name="name">cbFilePatching</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="draw_indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">14</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkSeparator">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">4</property>
+                                    <property name="position">15</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="cbNoLogs">
+                                    <property name="label" translatable="yes">No Logs</property>
+                                    <property name="name">cbNoLogs</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="draw_indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">16</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkSeparator">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">4</property>
+                                    <property name="position">17</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="cbShowScriptErrors">
+                                    <property name="label" translatable="yes">Show Script Errors</property>
+                                    <property name="name">cbShowScriptErrors</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="draw_indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">18</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkSeparator">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">4</property>
+                                    <property name="position">19</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -821,7 +905,7 @@
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">True</property>
-                                    <property name="position">14</property>
+                                    <property name="position">20</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -833,7 +917,7 @@
                                     <property name="expand">False</property>
                                     <property name="fill">True</property>
                                     <property name="padding">4</property>
-                                    <property name="position">15</property>
+                                    <property name="position">21</property>
                                   </packing>
                                 </child>
                                 <child>
@@ -848,7 +932,7 @@
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">True</property>
-                                    <property name="position">16</property>
+                                    <property name="position">22</property>
                                   </packing>
                                 </child>
                               </object>

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -59,8 +59,12 @@ MainWindow::MainWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk::Builder>
     builder->get_widget("cbExThreadsGeometryLoading", cbExThreadsGeometryLoading);
 
     builder->get_widget("cbEnableHT", cbEnableHT);
+	builder->get_widget("cbDisableMulticore", cbDisableMulticore);
+	builder->get_widget("cbHugePages", cbHugePages);
+	
     builder->get_widget("cbFilePatching", cbFilePatching);
     builder->get_widget("cbNoLogs", cbNoLogs);
+	builder->get_widget("cbShowScriptErrors", cbShowScriptErrors);
 
     builder->get_widget("cbWorld", cbWorld);
     builder->get_widget("tbWorld", tbWorld);
@@ -106,8 +110,12 @@ MainWindow::MainWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk::Builder>
     cbExThreadsGeometryLoading->set_active(Settings::ExThreadsGeometryLoading);
 
     cbEnableHT->set_active(Settings::EnableHT);
+	cbDisableMulticore->set_active(Settings::DisableMulticore);
+	cbHugePages->set_active(Settings::HugePages);
+	
     cbFilePatching->set_active(Settings::FilePatching);
     cbNoLogs->set_active(Settings::NoLogs);
+	cbShowScriptErrors->set_active(Settings::ShowScriptErrors);
 
     cbWorld->set_active(Settings::World);
     tbWorld->set_text(Settings::WorldValue);
@@ -149,8 +157,12 @@ MainWindow::MainWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk::Builder>
     cbExThreadsGeometryLoading->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbExThreadsGeometryLoading_Toggled));
 
     cbEnableHT->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbEnableHT_Toggled));
+	cbDisableMulticore->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbDisableMulticore_Toggled));
+	cbHugePages->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbHugePages_Toggled));
+	
     cbFilePatching->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbFilePatching_Toggled));
     cbNoLogs->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbNoLogs_Toggled));
+	cbShowScriptErrors->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbShowScriptErrors_Toggled));
 
     cbWorld->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbWorld_Toggled));
     tbWorld->signal_changed().connect(sigc::mem_fun(*this, &MainWindow::tbWorld_Changed));
@@ -188,8 +200,11 @@ MainWindow::MainWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk::Builder>
     cbExThreadsTextureLoading_Toggled();
     cbExThreadsGeometryLoading_Toggled();
     cbEnableHT_Toggled();
+	cbDisableMulticore_Toggled();
+	cbHugePages_Toggled();
     cbFilePatching_Toggled();
     cbNoLogs_Toggled();
+	cbShowScriptErrors_Toggled();
     cbWorld_Toggled();
     tbWorld_Changed();
     cbNoPause_Toggled();
@@ -543,6 +558,18 @@ void MainWindow::cbEnableHT_Toggled()
     if (!ignore) Settings::EnableHT = cbEnableHT->get_active();
 }
 
+void MainWindow::cbDisableMulticore_Toggled()
+{
+	LOG(0, "cbDisableMulticore_Toggled: " + Utils::ToString(cbDisableMulticore->get_active()));
+	if(!ignore) Settings::DisableMulticore = cbDisableMulticore->get_active();
+}
+
+void MainWindow::cbHugePages_Toggled()
+{
+	LOG(0, "cbHugePages_Toggled: " + Utils::ToString(cbHugePages->get_active()));
+	if(!ignore) Settings::HugePages = cbHugePages->get_active();
+}
+
 void MainWindow::cbFilePatching_Toggled()
 {
     LOG(0, "cbFilePatching_Toggled: " + Utils::ToString(cbFilePatching->get_active()));
@@ -553,6 +580,12 @@ void MainWindow::cbNoLogs_Toggled()
 {
     LOG(0, "cbNoLogs_Toggled: " + Utils::ToString(cbNoLogs->get_active()));
     if (!ignore) Settings::NoLogs = cbNoLogs->get_active();
+}
+
+void MainWindow::cbShowScriptErrors_Toggled()
+{
+	LOG(0, "cbShowScriptErrors_Toggled: " + Utils::ToString(cbShowScriptErrors->get_active()));
+	if (!ignore) Settings::ShowScriptErrors = cbShowScriptErrors->get_active();
 }
 
 void MainWindow::cbWorld_Toggled()
@@ -668,36 +701,40 @@ void MainWindow::btnPlay_Clicked()
     Filesystem::WriteAllText(Filesystem::HomeDirectory + Filesystem::ArmaConfigFile, newArmaCfg);
     LOG(0, "Arma3.cfg:\n--------------------\n" + newArmaCfg + "\n--------------------");
 
-    parameters += Settings::SkipIntro       ? "-skipIntro " : "";
-    parameters += Settings::Nosplash        ? "-nosplash " : "";
-    parameters += Settings::Window          ? "-window " : "";
-    parameters += Settings::Name            ? "-name=" + Settings::NameValue + " " : "";
+    parameters += Settings::SkipIntro       	? "-skipIntro " : "";
+    parameters += Settings::Nosplash        	? "-nosplash " : "";
+    parameters += Settings::Window          	? "-window " : "";
+    parameters += Settings::Name            	? "-name=" + Settings::NameValue + " " : "";
 
-    parameters += Settings::ParameterFile   ? "-par=" + Settings::ParameterFileValue + " " : "";
+    parameters += Settings::ParameterFile   	? "-par=" + Settings::ParameterFileValue + " " : "";
 
-    parameters += Settings::CheckSignatures ? "-checkSignatures " : "";
+    parameters += Settings::CheckSignatures 	? "-checkSignatures " : "";
 
-    parameters += Settings::CpuCount        ? "-cpuCount=" + std::to_string(Settings::CpuCountValue) + " "  : "";
+    parameters += Settings::CpuCount        	? "-cpuCount=" + std::to_string(Settings::CpuCountValue) + " "  : "";
 
     int exThreadsValue = Settings::ExThreadsFileOperations
                          + Settings::ExThreadsTextureLoading * 2
                          + Settings::ExThreadsGeometryLoading * 4;
 
-    parameters += Settings::ExThreads       ? "-exThreads=" + std::to_string(exThreadsValue) + " " : "";
+    parameters += Settings::ExThreads       	? "-exThreads=" + std::to_string(exThreadsValue) + " " : "";
 
-    parameters += Settings::EnableHT        ? "-enableHT " : "";
-    parameters += Settings::FilePatching    ? "-filePatching " : "";
-    parameters += Settings::NoLogs          ? "-noLogs " : "";
+    parameters += Settings::EnableHT        	? "-enableHT " : "";
+	parameters += Settings::DisableMulticore	? "-noCB " : "";
+	parameters += Settings::HugePages 			? "-hugepages " : "";
+	
+    parameters += Settings::FilePatching    	? "-filePatching " : "";
+    parameters += Settings::NoLogs          	? "-noLogs " : "";
+	parameters += Settings::ShowScriptErrors	? "-showScriptErrors " : "";
 
-    parameters += Settings::World           ? "-world=" + Settings::WorldValue + " " : "";
+    parameters += Settings::World           	? "-world=" + Settings::WorldValue + " " : "";
 
-    parameters += Settings::NoPause         ? "-noPause " : "";
+    parameters += Settings::NoPause         	? "-noPause " : "";
 
-    parameters += Settings::Connect         ? "-connect=" + Settings::ConnectValue + " " : "";
-    parameters += Settings::Port            ? "-port=" + Settings::PortValue + " " : "";
-    parameters += Settings::Password        ? "-password=" + Settings::PasswordValue + " " : "";
+    parameters += Settings::Connect         	? "-connect=" + Settings::ConnectValue + " " : "";
+    parameters += Settings::Port            	? "-port=" + Settings::PortValue + " " : "";
+    parameters += Settings::Password        	? "-password=" + Settings::PasswordValue + " " : "";
 
-    parameters += Settings::Host            ? "-host" : "";
+    parameters += Settings::Host            	? "-host" : "";
 
     LOG(0, "Arma 3 launch command:\n" + Settings::ArmaPath + "/arma " + parameters);
 

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -805,14 +805,32 @@ void MainWindow::Init()
     std::vector<Mod> ArmaDirMods = Filesystem::FindMods(Settings::ArmaPath);
     for (Mod m : ArmaDirMods)
     {
+        bool alreadyExists = false;
         for (Mod n : CustomMods)
         {
             if (n.Path == m.Path)
-                goto alreadyExists;
+                alreadyExists = true;
         }
-        CustomMods.push_back(m);
-alreadyExists:
-        continue;
+        if (!alreadyExists)
+            CustomMods.push_back(m);
+    }
+
+    // Removes CustomMods that are not located inside the ArmaDir anymore.
+    for (std::vector<Mod>::iterator it = CustomMods.begin(); it != CustomMods.end();)
+    {
+        bool found = false;
+        for (Mod m : ArmaDirMods)
+        {
+            if (it->Path == m.Path)
+            {
+                found = true;
+                break;
+            }
+        }
+        if (!found)
+            it = CustomMods.erase(it);
+        else
+            it++;
     }
 
     FullModList.clear();

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -59,12 +59,12 @@ MainWindow::MainWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk::Builder>
     builder->get_widget("cbExThreadsGeometryLoading", cbExThreadsGeometryLoading);
 
     builder->get_widget("cbEnableHT", cbEnableHT);
-	builder->get_widget("cbDisableMulticore", cbDisableMulticore);
-	builder->get_widget("cbHugePages", cbHugePages);
-	
+    builder->get_widget("cbDisableMulticore", cbDisableMulticore);
+    builder->get_widget("cbHugePages", cbHugePages);
+
     builder->get_widget("cbFilePatching", cbFilePatching);
     builder->get_widget("cbNoLogs", cbNoLogs);
-	builder->get_widget("cbShowScriptErrors", cbShowScriptErrors);
+    builder->get_widget("cbShowScriptErrors", cbShowScriptErrors);
 
     builder->get_widget("cbWorld", cbWorld);
     builder->get_widget("tbWorld", tbWorld);
@@ -110,12 +110,12 @@ MainWindow::MainWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk::Builder>
     cbExThreadsGeometryLoading->set_active(Settings::ExThreadsGeometryLoading);
 
     cbEnableHT->set_active(Settings::EnableHT);
-	cbDisableMulticore->set_active(Settings::DisableMulticore);
-	cbHugePages->set_active(Settings::HugePages);
-	
+    cbDisableMulticore->set_active(Settings::DisableMulticore);
+    cbHugePages->set_active(Settings::HugePages);
+
     cbFilePatching->set_active(Settings::FilePatching);
     cbNoLogs->set_active(Settings::NoLogs);
-	cbShowScriptErrors->set_active(Settings::ShowScriptErrors);
+    cbShowScriptErrors->set_active(Settings::ShowScriptErrors);
 
     cbWorld->set_active(Settings::World);
     tbWorld->set_text(Settings::WorldValue);
@@ -157,12 +157,12 @@ MainWindow::MainWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk::Builder>
     cbExThreadsGeometryLoading->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbExThreadsGeometryLoading_Toggled));
 
     cbEnableHT->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbEnableHT_Toggled));
-	cbDisableMulticore->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbDisableMulticore_Toggled));
-	cbHugePages->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbHugePages_Toggled));
-	
+    cbDisableMulticore->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbDisableMulticore_Toggled));
+    cbHugePages->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbHugePages_Toggled));
+
     cbFilePatching->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbFilePatching_Toggled));
     cbNoLogs->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbNoLogs_Toggled));
-	cbShowScriptErrors->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbShowScriptErrors_Toggled));
+    cbShowScriptErrors->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbShowScriptErrors_Toggled));
 
     cbWorld->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbWorld_Toggled));
     tbWorld->signal_changed().connect(sigc::mem_fun(*this, &MainWindow::tbWorld_Changed));
@@ -200,11 +200,11 @@ MainWindow::MainWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk::Builder>
     cbExThreadsTextureLoading_Toggled();
     cbExThreadsGeometryLoading_Toggled();
     cbEnableHT_Toggled();
-	cbDisableMulticore_Toggled();
-	cbHugePages_Toggled();
+    cbDisableMulticore_Toggled();
+    cbHugePages_Toggled();
     cbFilePatching_Toggled();
     cbNoLogs_Toggled();
-	cbShowScriptErrors_Toggled();
+    cbShowScriptErrors_Toggled();
     cbWorld_Toggled();
     tbWorld_Changed();
     cbNoPause_Toggled();
@@ -560,14 +560,14 @@ void MainWindow::cbEnableHT_Toggled()
 
 void MainWindow::cbDisableMulticore_Toggled()
 {
-	LOG(0, "cbDisableMulticore_Toggled: " + Utils::ToString(cbDisableMulticore->get_active()));
-	if(!ignore) Settings::DisableMulticore = cbDisableMulticore->get_active();
+    LOG(0, "cbDisableMulticore_Toggled: " + Utils::ToString(cbDisableMulticore->get_active()));
+    if (!ignore) Settings::DisableMulticore = cbDisableMulticore->get_active();
 }
 
 void MainWindow::cbHugePages_Toggled()
 {
-	LOG(0, "cbHugePages_Toggled: " + Utils::ToString(cbHugePages->get_active()));
-	if(!ignore) Settings::HugePages = cbHugePages->get_active();
+    LOG(0, "cbHugePages_Toggled: " + Utils::ToString(cbHugePages->get_active()));
+    if (!ignore) Settings::HugePages = cbHugePages->get_active();
 }
 
 void MainWindow::cbFilePatching_Toggled()
@@ -584,8 +584,8 @@ void MainWindow::cbNoLogs_Toggled()
 
 void MainWindow::cbShowScriptErrors_Toggled()
 {
-	LOG(0, "cbShowScriptErrors_Toggled: " + Utils::ToString(cbShowScriptErrors->get_active()));
-	if (!ignore) Settings::ShowScriptErrors = cbShowScriptErrors->get_active();
+    LOG(0, "cbShowScriptErrors_Toggled: " + Utils::ToString(cbShowScriptErrors->get_active()));
+    if (!ignore) Settings::ShowScriptErrors = cbShowScriptErrors->get_active();
 }
 
 void MainWindow::cbWorld_Toggled()
@@ -701,40 +701,40 @@ void MainWindow::btnPlay_Clicked()
     Filesystem::WriteAllText(Filesystem::HomeDirectory + Filesystem::ArmaConfigFile, newArmaCfg);
     LOG(0, "Arma3.cfg:\n--------------------\n" + newArmaCfg + "\n--------------------");
 
-    parameters += Settings::SkipIntro       	? "-skipIntro " : "";
-    parameters += Settings::Nosplash        	? "-nosplash " : "";
-    parameters += Settings::Window          	? "-window " : "";
-    parameters += Settings::Name            	? "-name=" + Settings::NameValue + " " : "";
+    parameters += Settings::SkipIntro           ? "-skipIntro " : "";
+    parameters += Settings::Nosplash            ? "-nosplash " : "";
+    parameters += Settings::Window              ? "-window " : "";
+    parameters += Settings::Name                ? "-name=" + Settings::NameValue + " " : "";
 
-    parameters += Settings::ParameterFile   	? "-par=" + Settings::ParameterFileValue + " " : "";
+    parameters += Settings::ParameterFile       ? "-par=" + Settings::ParameterFileValue + " " : "";
 
-    parameters += Settings::CheckSignatures 	? "-checkSignatures " : "";
+    parameters += Settings::CheckSignatures     ? "-checkSignatures " : "";
 
-    parameters += Settings::CpuCount        	? "-cpuCount=" + std::to_string(Settings::CpuCountValue) + " "  : "";
+    parameters += Settings::CpuCount            ? "-cpuCount=" + std::to_string(Settings::CpuCountValue) + " "  : "";
 
     int exThreadsValue = Settings::ExThreadsFileOperations
                          + Settings::ExThreadsTextureLoading * 2
                          + Settings::ExThreadsGeometryLoading * 4;
 
-    parameters += Settings::ExThreads       	? "-exThreads=" + std::to_string(exThreadsValue) + " " : "";
+    parameters += Settings::ExThreads           ? "-exThreads=" + std::to_string(exThreadsValue) + " " : "";
 
-    parameters += Settings::EnableHT        	? "-enableHT " : "";
-	parameters += Settings::DisableMulticore	? "-noCB " : "";
-	parameters += Settings::HugePages 			? "-hugepages " : "";
-	
-    parameters += Settings::FilePatching    	? "-filePatching " : "";
-    parameters += Settings::NoLogs          	? "-noLogs " : "";
-	parameters += Settings::ShowScriptErrors	? "-showScriptErrors " : "";
+    parameters += Settings::EnableHT            ? "-enableHT " : "";
+    parameters += Settings::DisableMulticore    ? "-noCB " : "";
+    parameters += Settings::HugePages           ? "-hugepages " : "";
 
-    parameters += Settings::World           	? "-world=" + Settings::WorldValue + " " : "";
+    parameters += Settings::FilePatching        ? "-filePatching " : "";
+    parameters += Settings::NoLogs              ? "-noLogs " : "";
+    parameters += Settings::ShowScriptErrors    ? "-showScriptErrors " : "";
 
-    parameters += Settings::NoPause         	? "-noPause " : "";
+    parameters += Settings::World               ? "-world=" + Settings::WorldValue + " " : "";
 
-    parameters += Settings::Connect         	? "-connect=" + Settings::ConnectValue + " " : "";
-    parameters += Settings::Port            	? "-port=" + Settings::PortValue + " " : "";
-    parameters += Settings::Password        	? "-password=" + Settings::PasswordValue + " " : "";
+    parameters += Settings::NoPause             ? "-noPause " : "";
 
-    parameters += Settings::Host            	? "-host" : "";
+    parameters += Settings::Connect             ? "-connect=" + Settings::ConnectValue + " " : "";
+    parameters += Settings::Port                ? "-port=" + Settings::PortValue + " " : "";
+    parameters += Settings::Password            ? "-password=" + Settings::PasswordValue + " " : "";
+
+    parameters += Settings::Host                ? "-host" : "";
 
     LOG(0, "Arma 3 launch command:\n" + Settings::ArmaPath + "/arma " + parameters);
 

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -55,12 +55,12 @@ class MainWindow : public Gtk::Window
         Gtk::CheckButton *cbExThreadsGeometryLoading;
 
         Gtk::CheckButton *cbEnableHT;
-		Gtk::CheckButton *cbDisableMulticore;
-		Gtk::CheckButton *cbHugePages;
-		
+        Gtk::CheckButton *cbDisableMulticore;
+        Gtk::CheckButton *cbHugePages;
+
         Gtk::CheckButton *cbFilePatching;
         Gtk::CheckButton *cbNoLogs;
-		Gtk::CheckButton *cbShowScriptErrors;
+        Gtk::CheckButton *cbShowScriptErrors;
 
         Gtk::CheckButton *cbWorld;
         Gtk::Entry *tbWorld;
@@ -160,12 +160,12 @@ class MainWindow : public Gtk::Window
         void cbExThreadsGeometryLoading_Toggled();
 
         void cbEnableHT_Toggled();
-		void cbDisableMulticore_Toggled();
-		void cbHugePages_Toggled();
-		
+        void cbDisableMulticore_Toggled();
+        void cbHugePages_Toggled();
+
         void cbFilePatching_Toggled();
         void cbNoLogs_Toggled();
-		void cbShowScriptErrors_Toggled();
+        void cbShowScriptErrors_Toggled();
 
         void cbWorld_Toggled();
         void tbWorld_Changed();

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -55,8 +55,12 @@ class MainWindow : public Gtk::Window
         Gtk::CheckButton *cbExThreadsGeometryLoading;
 
         Gtk::CheckButton *cbEnableHT;
+		Gtk::CheckButton *cbDisableMulticore;
+		Gtk::CheckButton *cbHugePages;
+		
         Gtk::CheckButton *cbFilePatching;
         Gtk::CheckButton *cbNoLogs;
+		Gtk::CheckButton *cbShowScriptErrors;
 
         Gtk::CheckButton *cbWorld;
         Gtk::Entry *tbWorld;
@@ -156,8 +160,12 @@ class MainWindow : public Gtk::Window
         void cbExThreadsGeometryLoading_Toggled();
 
         void cbEnableHT_Toggled();
+		void cbDisableMulticore_Toggled();
+		void cbHugePages_Toggled();
+		
         void cbFilePatching_Toggled();
         void cbNoLogs_Toggled();
+		void cbShowScriptErrors_Toggled();
 
         void cbWorld_Toggled();
         void tbWorld_Changed();

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -22,7 +22,7 @@ namespace Settings
 {
     string ArmaPath = Filesystem::DIR_NOT_FOUND;
     string WorkshopPath = Filesystem::DIR_NOT_FOUND;
-	
+
     int WindowPosX = 0;
     int WindowPosY = 0;
     int WindowSizeX = 800;
@@ -48,12 +48,12 @@ namespace Settings
     bool ExThreadsGeometryLoading = false;
 
     bool EnableHT = false;
-	bool DisableMulticore = false;
-	bool HugePages = false;
-	
+    bool DisableMulticore = false;
+    bool HugePages = false;
+
     bool FilePatching = false;
     bool NoLogs = false;
-	bool ShowScriptErrors = false;
+    bool ShowScriptErrors = false;
 
     bool World = false;
     string WorldValue = "";
@@ -135,16 +135,16 @@ namespace Settings
                     ExThreadsGeometryLoading = strtol(line.substr(25).c_str(), NULL, 10);
                 else if (Utils::StartsWith(line, "EnableHT="))
                     EnableHT = strtol(line.substr(9).c_str(), NULL, 10);
-				else if (Utils::StartsWith(line, "DisableMulticore="))
-					DisableMulticore = strtol(line.substr(17).c_str(), NULL, 10);
-				else if (Utils::StartsWith(line, "HugePages="))
-					HugePages = strtol(line.substr(10).c_str(), NULL, 10);
+                else if (Utils::StartsWith(line, "DisableMulticore="))
+                    DisableMulticore = strtol(line.substr(17).c_str(), NULL, 10);
+                else if (Utils::StartsWith(line, "HugePages="))
+                    HugePages = strtol(line.substr(10).c_str(), NULL, 10);
                 else if (Utils::StartsWith(line, "FilePatching="))
                     FilePatching = strtol(line.substr(13).c_str(), NULL, 10);
                 else if (Utils::StartsWith(line, "NoLogs="))
                     NoLogs = strtol(line.substr(7).c_str(), NULL, 10);
-				else if (Utils::StartsWith(line, "ShowScriptErrors="))
-					ShowScriptErrors = strtol(line.substr(17).c_str(), NULL, 10);
+                else if (Utils::StartsWith(line, "ShowScriptErrors="))
+                    ShowScriptErrors = strtol(line.substr(17).c_str(), NULL, 10);
                 else if (Utils::StartsWith(line, "World="))
                     World = strtol(line.substr(6).c_str(), NULL, 10);
                 else if (Utils::StartsWith(line, "WorldValue="))
@@ -224,11 +224,11 @@ namespace Settings
                          + "\nExThreadsTextureLoading=" + Utils::ToString(ExThreadsTextureLoading)
                          + "\nExThreadsGeometryLoading=" + Utils::ToString(ExThreadsGeometryLoading)
                          + "\nEnableHT=" + Utils::ToString(EnableHT)
-						 + "\nDisableMulticore=" + Utils::ToString(DisableMulticore)
-						 + "\nHugePages=" + Utils::ToString(HugePages)
+                         + "\nDisableMulticore=" + Utils::ToString(DisableMulticore)
+                         + "\nHugePages=" + Utils::ToString(HugePages)
                          + "\nFilePatching=" + Utils::ToString(FilePatching)
                          + "\nNoLogs=" + Utils::ToString(NoLogs)
-						 + "\nShowScriptErrors=" + Utils::ToString(ShowScriptErrors)
+                         + "\nShowScriptErrors=" + Utils::ToString(ShowScriptErrors)
                          + "\nWorld=" + Utils::ToString(World)
                          + "\nWorldValue=" + WorldValue
                          + "\nNoPause=" + Utils::ToString(NoPause)

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -22,7 +22,7 @@ namespace Settings
 {
     string ArmaPath = Filesystem::DIR_NOT_FOUND;
     string WorkshopPath = Filesystem::DIR_NOT_FOUND;
-
+	
     int WindowPosX = 0;
     int WindowPosY = 0;
     int WindowSizeX = 800;
@@ -48,8 +48,12 @@ namespace Settings
     bool ExThreadsGeometryLoading = false;
 
     bool EnableHT = false;
+	bool DisableMulticore = false;
+	bool HugePages = false;
+	
     bool FilePatching = false;
     bool NoLogs = false;
+	bool ShowScriptErrors = false;
 
     bool World = false;
     string WorldValue = "";
@@ -131,10 +135,16 @@ namespace Settings
                     ExThreadsGeometryLoading = strtol(line.substr(25).c_str(), NULL, 10);
                 else if (Utils::StartsWith(line, "EnableHT="))
                     EnableHT = strtol(line.substr(9).c_str(), NULL, 10);
+				else if (Utils::StartsWith(line, "DisableMulticore="))
+					DisableMulticore = strtol(line.substr(17).c_str(), NULL, 10);
+				else if (Utils::StartsWith(line, "HugePages="))
+					HugePages = strtol(line.substr(10).c_str(), NULL, 10);
                 else if (Utils::StartsWith(line, "FilePatching="))
                     FilePatching = strtol(line.substr(13).c_str(), NULL, 10);
                 else if (Utils::StartsWith(line, "NoLogs="))
                     NoLogs = strtol(line.substr(7).c_str(), NULL, 10);
+				else if (Utils::StartsWith(line, "ShowScriptErrors="))
+					ShowScriptErrors = strtol(line.substr(17).c_str(), NULL, 10);
                 else if (Utils::StartsWith(line, "World="))
                     World = strtol(line.substr(6).c_str(), NULL, 10);
                 else if (Utils::StartsWith(line, "WorldValue="))
@@ -214,8 +224,11 @@ namespace Settings
                          + "\nExThreadsTextureLoading=" + Utils::ToString(ExThreadsTextureLoading)
                          + "\nExThreadsGeometryLoading=" + Utils::ToString(ExThreadsGeometryLoading)
                          + "\nEnableHT=" + Utils::ToString(EnableHT)
+						 + "\nDisableMulticore=" + Utils::ToString(DisableMulticore)
+						 + "\nHugePages=" + Utils::ToString(HugePages)
                          + "\nFilePatching=" + Utils::ToString(FilePatching)
                          + "\nNoLogs=" + Utils::ToString(NoLogs)
+						 + "\nShowScriptErrors=" + Utils::ToString(ShowScriptErrors)
                          + "\nWorld=" + Utils::ToString(World)
                          + "\nWorldValue=" + WorldValue
                          + "\nNoPause=" + Utils::ToString(NoPause)

--- a/Settings.h
+++ b/Settings.h
@@ -43,12 +43,12 @@ namespace Settings
     extern bool ExThreadsGeometryLoading;
 
     extern bool EnableHT;
-	extern bool DisableMulticore;
-	extern bool HugePages;
-	
+    extern bool DisableMulticore;
+    extern bool HugePages;
+
     extern bool FilePatching;
     extern bool NoLogs;
-	extern bool ShowScriptErrors;
+    extern bool ShowScriptErrors;
 
     extern bool World;
     extern std::string WorldValue;

--- a/Settings.h
+++ b/Settings.h
@@ -43,8 +43,12 @@ namespace Settings
     extern bool ExThreadsGeometryLoading;
 
     extern bool EnableHT;
+	extern bool DisableMulticore;
+	extern bool HugePages;
+	
     extern bool FilePatching;
     extern bool NoLogs;
+	extern bool ShowScriptErrors;
 
     extern bool World;
     extern std::string WorldValue;


### PR DESCRIPTION
Added Parameters `-hugePages`, `-noCB` and `-showScriptErrors`
Now removing all entries from "CustomMods" that are not found inside the ArmA3 Directory anymore.
Also replaced the `goto` in finding existing mods with an if check.