### PR TITLE
Fix 64bit Executable and Parameters

### DIFF
--- a/Filesystem.cpp
+++ b/Filesystem.cpp
@@ -186,8 +186,9 @@ namespace Filesystem
 
         for (string s : GetSubDirectories(path))
         {
-            if (s == "curator" || s == "dta" || s == "Expansion" || s == "heli"
-                    || s == "kart" || s == "mark") //skip DLCs
+			if (s == "Curator" || s == "Dta" || s == "Expansion" || s == "Heli"
+					|| s == "Jets" || s == "Kart" || s == "Mark" || s == "Argo"
+					|| s == "Orange") //skip DLCs
                 continue;
             if (DirectoryExists(path + "/" + s + "/Addons")
                     || DirectoryExists(path + "/" + s + "/addons"))

--- a/Filesystem.cpp
+++ b/Filesystem.cpp
@@ -186,9 +186,9 @@ namespace Filesystem
 
         for (string s : GetSubDirectories(path))
         {
-			if (s == "Curator" || s == "Dta" || s == "Expansion" || s == "Heli"
-					|| s == "Jets" || s == "Kart" || s == "Mark" || s == "Argo"
-					|| s == "Orange") //skip DLCs
+            if (s == "Curator" || s == "Dta" || s == "Expansion" || s == "Heli"
+                    || s == "Jets" || s == "Kart" || s == "Mark" || s == "Argo"
+                    || s == "Orange") //skip DLCs
                 continue;
             if (DirectoryExists(path + "/" + s + "/Addons")
                     || DirectoryExists(path + "/" + s + "/addons"))

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -182,8 +182,8 @@ MainWindow::MainWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk::Builder>
 
     btnPlay->signal_clicked().connect(sigc::mem_fun(*this, &MainWindow::btnPlay_Clicked));
 
-	cbNosplash->set_tooltip_text("(1.70) Game will Crash if you enable this and alt tab during the initial loading screen!"
-								 "\nWait until you're in the main menu!");
+    cbNosplash->set_tooltip_text("(1.70) Game will Crash if you enable this and alt tab during the initial loading screen!"
+                                 "\nWait until you're in the main menu!");
 
     /////Executing every event - need to make sure UI represents actual Settings
     ignore = true;
@@ -292,7 +292,7 @@ void MainWindow::ArmaStatusThread()
         #ifdef __APPLE__
         armaPid = Utils::FindProcess("ArmA3");
         #else
-		armaPid = Utils::FindProcess("./arma3.x86_64");
+        armaPid = Utils::FindProcess("./arma3.x86_64");
         #endif
         if (armaPid != -1)
             lblStatus->set_text("Status: ArmA 3 running, PID: " + std::to_string(armaPid));
@@ -705,7 +705,7 @@ void MainWindow::btnPlay_Clicked()
     LOG(0, "Arma3.cfg:\n--------------------\n" + newArmaCfg + "\n--------------------");
 
     parameters += Settings::SkipIntro           ? "-skipIntro " : "";
-	parameters += Settings::Nosplash            ? "-noSplash " : "";
+    parameters += Settings::Nosplash            ? "-noSplash " : "";
     parameters += Settings::Window              ? "-window " : "";
     parameters += Settings::Name                ? "-name=" + Settings::NameValue + " " : "";
 
@@ -723,7 +723,7 @@ void MainWindow::btnPlay_Clicked()
 
     parameters += Settings::EnableHT            ? "-enableHT " : "";
     parameters += Settings::DisableMulticore    ? "-noCB " : "";
-	parameters += Settings::HugePages           ? "-hugePages " : "";
+    parameters += Settings::HugePages           ? "-hugePages " : "";
 
     parameters += Settings::FilePatching        ? "-filePatching " : "";
     parameters += Settings::NoLogs              ? "-noLogs " : "";

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -289,7 +289,7 @@ void MainWindow::ArmaStatusThread()
         #ifdef __APPLE__
         armaPid = Utils::FindProcess("ArmA3");
         #else
-        armaPid = Utils::FindProcess("./arma3.i386");
+		armaPid = Utils::FindProcess("./arma3.x86_64");
         #endif
         if (armaPid != -1)
             lblStatus->set_text("Status: ArmA 3 running, PID: " + std::to_string(armaPid));
@@ -702,7 +702,7 @@ void MainWindow::btnPlay_Clicked()
     LOG(0, "Arma3.cfg:\n--------------------\n" + newArmaCfg + "\n--------------------");
 
     parameters += Settings::SkipIntro           ? "-skipIntro " : "";
-    parameters += Settings::Nosplash            ? "-nosplash " : "";
+	parameters += Settings::Nosplash            ? "-noSplash " : "";
     parameters += Settings::Window              ? "-window " : "";
     parameters += Settings::Name                ? "-name=" + Settings::NameValue + " " : "";
 
@@ -720,7 +720,7 @@ void MainWindow::btnPlay_Clicked()
 
     parameters += Settings::EnableHT            ? "-enableHT " : "";
     parameters += Settings::DisableMulticore    ? "-noCB " : "";
-    parameters += Settings::HugePages           ? "-hugepages " : "";
+	parameters += Settings::HugePages           ? "-hugePages " : "";
 
     parameters += Settings::FilePatching        ? "-filePatching " : "";
     parameters += Settings::NoLogs              ? "-noLogs " : "";

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -182,6 +182,9 @@ MainWindow::MainWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk::Builder>
 
     btnPlay->signal_clicked().connect(sigc::mem_fun(*this, &MainWindow::btnPlay_Clicked));
 
+	cbNosplash->set_tooltip_text("(1.70) Game will Crash if you enable this and alt tab during the initial loading screen!"
+								 "\nWait until you're in the main menu!");
+
     /////Executing every event - need to make sure UI represents actual Settings
     ignore = true;
     cbSkipIntro_Toggled();

--- a/main.cpp
+++ b/main.cpp
@@ -142,12 +142,12 @@ int main(int argc, char *argv[])
         if (result == 1)
         {
             string currentFolder = fcDialog.get_current_folder();
-            if (Filesystem::FileExists(currentFolder + "/arma3.i386")
+			if (Filesystem::FileExists(currentFolder + "/arma3.x86_64")
                     || Filesystem::FileExists(currentFolder + "/ArmA3.app")
                     || Filesystem::DirectoryExists(currentFolder + "/ArmA3.app"))
                 Settings::ArmaPath = currentFolder;
             currentFolder = fcDialog.get_filename();
-            if (Filesystem::FileExists(currentFolder + "/arma3.i386")
+			if (Filesystem::FileExists(currentFolder + "/arma3.x86_64")
                     || Filesystem::FileExists(currentFolder + "/ArmA3.app")
                     || Filesystem::DirectoryExists(currentFolder + "/ArmA3.app"))
                 Settings::ArmaPath = currentFolder;
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
             if (Settings::ArmaPath == Filesystem::DIR_NOT_FOUND)
             {
                 string Message2 = string("Selected directory seems incorrect") +
-                                  "\n" + currentFolder + "/arma3.i386 doesn't exist"
+								  "\n" + currentFolder + "/arma3.x86_64 doesn't exist"
                                   "\n" + currentFolder + "/ArmA3.app doesn't exist";
 
                 Gtk::MessageDialog msg2(Message2);

--- a/main.cpp
+++ b/main.cpp
@@ -142,12 +142,12 @@ int main(int argc, char *argv[])
         if (result == 1)
         {
             string currentFolder = fcDialog.get_current_folder();
-			if (Filesystem::FileExists(currentFolder + "/arma3.x86_64")
+            if (Filesystem::FileExists(currentFolder + "/arma3.x86_64")
                     || Filesystem::FileExists(currentFolder + "/ArmA3.app")
                     || Filesystem::DirectoryExists(currentFolder + "/ArmA3.app"))
                 Settings::ArmaPath = currentFolder;
             currentFolder = fcDialog.get_filename();
-			if (Filesystem::FileExists(currentFolder + "/arma3.x86_64")
+            if (Filesystem::FileExists(currentFolder + "/arma3.x86_64")
                     || Filesystem::FileExists(currentFolder + "/ArmA3.app")
                     || Filesystem::DirectoryExists(currentFolder + "/ArmA3.app"))
                 Settings::ArmaPath = currentFolder;
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
             if (Settings::ArmaPath == Filesystem::DIR_NOT_FOUND)
             {
                 string Message2 = string("Selected directory seems incorrect") +
-								  "\n" + currentFolder + "/arma3.x86_64 doesn't exist"
+                                  "\n" + currentFolder + "/arma3.x86_64 doesn't exist"
                                   "\n" + currentFolder + "/ArmA3.app doesn't exist";
 
                 Gtk::MessageDialog msg2(Message2);


### PR DESCRIPTION
Update 1.70 exchanged the 32bit for a 64bit executable, thus it is now called arma3.x86_64 instead of arma3.i386
For some reason, startup parameters seem to be case sensitive now.
There is also a bug that crashes the game if you alt-tab out of ArmA immediately after starting it with -noSplash. Added a Warning Tooltip.