### PR TITLE
Added Mod Preset System

### DIFF
--- a/MainForm.glade
+++ b/MainForm.glade
@@ -215,6 +215,18 @@
                     <property name="can_focus">False</property>
                     <property name="homogeneous">True</property>
                     <child>
+                    <object class="GtkLabel"> 
+                        <property name="visible">True</property> 
+                        <property name="can_focus">False</property> 
+                        <property name="label" translatable="yes">Custom Mods:</property> 
+                      </object> 
+                      <packing> 
+                        <property name="expand">False</property> 
+                        <property name="fill">True</property> 
+                        <property name="position">0</property> 
+                      </packing> 
+                    </child> 
+                    <child> 
                       <object class="GtkButton" id="btnAdd">
                         <property name="label">gtk-add</property>
                         <property name="visible">True</property>
@@ -226,7 +238,7 @@
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">0</property>
+                        <property name="position">1</property>
                       </packing>
                     </child>
                     <child>
@@ -241,7 +253,7 @@
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">1</property>
+                        <property name="position">2</property>
                       </packing>
                     </child>
                   </object>
@@ -1185,6 +1197,69 @@
           </packing>
         </child>
         <child>
+        <object class="GtkBox" id="presetsBox"> 
+            <property name="visible">True</property> 
+            <property name="can_focus">False</property> 
+            <property name="homogeneous">True</property> 
+            <child> 
+              <object class="GtkLabel"> 
+                <property name="visible">True</property> 
+                <property name="can_focus">False</property> 
+                <property name="label" translatable="yes">Mod Preset:</property> 
+              </object> 
+              <packing> 
+                <property name="expand">False</property> 
+                <property name="fill">True</property> 
+                <property name="position">0</property> 
+              </packing> 
+            </child> 
+            <child> 
+              <object class="GtkButton" id="btnPresetLoad"> 
+                <property name="label">gtk-open</property> 
+                <property name="visible">True</property> 
+                <property name="can_focus">True</property> 
+                <property name="receives_default">True</property> 
+                <property name="use_stock">True</property> 
+              </object> 
+              <packing> 
+                <property name="expand">False</property> 
+                <property name="fill">True</property> 
+                <property name="position">1</property> 
+              </packing> 
+            </child> 
+            <child> 
+              <object class="GtkButton" id="btnPresetSave"> 
+                <property name="label">gtk-save</property> 
+                <property name="visible">True</property> 
+                <property name="can_focus">True</property> 
+                <property name="receives_default">True</property> 
+                <property name="use_stock">True</property> 
+              </object> 
+              <packing> 
+                <property name="expand">False</property> 
+                <property name="fill">True</property> 
+                <property name="position">2</property> 
+              </packing> 
+            </child> 
+          </object> 
+          <packing> 
+            <property name="expand">False</property> 
+            <property name="fill">True</property> 
+            <property name="position">1</property> 
+          </packing> 
+        </child> 
+        <child> 
+          <object class="GtkSeparator"> 
+            <property name="visible">True</property> 
+            <property name="can_focus">False</property> 
+          </object> 
+          <packing> 
+            <property name="expand">False</property> 
+            <property name="fill">True</property> 
+            <property name="position">2</property> 
+          </packing> 
+        </child> 
+        <child> 
           <object class="GtkLabel" id="lblSelectedMods">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
@@ -1193,7 +1268,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">3</property>
           </packing>
         </child>
         <child>
@@ -1237,7 +1312,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">4</property>
           </packing>
         </child>
       </object>

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -32,6 +32,9 @@ MainWindow::MainWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk::Builder>
     builder->get_widget("btnAdd", btnAdd);
     builder->get_widget("btnRemove", btnRemove);
 
+    builder->get_widget("btnPresetLoad", btnPresetLoad);
+    builder->get_widget("btnPresetSave", btnPresetSave);
+
     workshopToggleBox = Glib::RefPtr<Gtk::CellRendererToggle>::cast_dynamic(builder->get_object("workshopToggleBox"));
     customToggleBox = Glib::RefPtr<Gtk::CellRendererToggle>::cast_dynamic(builder->get_object("customToggleBox"));
 
@@ -135,6 +138,9 @@ MainWindow::MainWindow(BaseObjectType *cobject, const Glib::RefPtr<Gtk::Builder>
 
     btnAdd->signal_clicked().connect(sigc::mem_fun(*this, &MainWindow::btnAdd_Clicked));
     btnRemove->signal_clicked().connect(sigc::mem_fun(*this, &MainWindow::btnRemove_Clicked));
+
+    btnPresetLoad->signal_clicked().connect(sigc::mem_fun(*this, &MainWindow::btnPresetLoad_Clicked));
+    btnPresetSave->signal_clicked().connect(sigc::mem_fun(*this, &MainWindow::btnPresetSave_Clicked));
 
     cbSkipIntro->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbSkipIntro_Toggled));
     cbNosplash->signal_toggled().connect(sigc::mem_fun(*this, &MainWindow::cbNosplash_Toggled));
@@ -388,6 +394,92 @@ void MainWindow::btnRemove_Clicked()
     RefreshStatusLabel();
 }
 
+void MainWindow::btnPresetLoad_Clicked()
+{
+    Gtk::FileChooserDialog fcDialog(*this, "Select a Preset", Gtk::FILE_CHOOSER_ACTION_OPEN);
+    fcDialog.add_button("_Open", 1);
+    fcDialog.add_button("_Cancel", 0);
+    fcDialog.set_current_folder(Filesystem::HomeDirectory + Filesystem::LauncherSettingsDirectory);
+    int result = fcDialog.run();
+
+    if (result)
+    {
+        std::string fname = fcDialog.get_filename();
+        Settings::ModPreset = fname.substr(fname.find_last_of('/') + 1);
+        std::string contents = Filesystem::ReadAllText(fcDialog.get_filename());
+        Settings::WorkshopModsEnabled.clear();
+        Settings::CustomModsEnabled.clear();
+
+        //load mods into settings
+        for (std::string line : Utils::Split(contents, "\n"))
+        {
+            if (Utils::StartsWith(line, "WorkshopModsEnabled="))
+            {
+                std::string sub = line.substr(20);
+                for (std::string s : Utils::Split(sub, ","))
+                    Settings::WorkshopModsEnabled.push_back(s);
+            }
+            else if (Utils::StartsWith(line, "CustomModsEnabled="))
+            {
+                std::string sub = line.substr(18);
+                for (std::string s : Utils::Split(sub, ","))
+                    Settings::CustomModsEnabled.push_back(s);
+            }
+        }
+
+        //update UI to reflect changes
+        for (int i = 0; i < workshopModsStore.operator ->()->children().size(); i++)
+        {
+            Gtk::TreeModel::Row row = *(workshopModsStore.operator ->()->get_iter(std::to_string(i).c_str()));
+
+            Glib::ustring workshopid = row[workshopColumns.workshopid];
+
+            row[workshopColumns.enabled] = Settings::ModEnabled(workshopid.raw());
+        }
+
+        for (int i = 0; i < customModsStore.operator ->()->children().size(); i++)
+        {
+            Gtk::TreeModel::Row row = *(customModsStore.operator ->()->get_iter(std::to_string(i).c_str()));
+
+            Glib::ustring path = row[customColumns.path];
+            std::string pathStr = Utils::Replace(path.raw(), Filesystem::ArmaDirMark, Settings::ArmaPath);
+
+            row[customColumns.enabled] = Settings::ModEnabled(pathStr);
+        }
+
+        RefreshStatusLabel();
+    }
+}
+
+void MainWindow::btnPresetSave_Clicked()
+{
+    PutModsToSettings();
+
+    Gtk::FileChooserDialog fcDialog(*this, "Name your Preset", Gtk::FILE_CHOOSER_ACTION_SAVE);
+    fcDialog.add_button("_Save", 1);
+    fcDialog.add_button("_Cancel", 0);
+    std::string path = Filesystem::HomeDirectory + Filesystem::LauncherSettingsDirectory;
+    fcDialog.set_current_folder(path);
+    int result = fcDialog.run();
+
+    if (result)
+    {
+        std::string fname = fcDialog.get_filename();
+        Settings::ModPreset = fname.substr(fname.find_last_of('/') + 1);
+        RefreshStatusLabel();
+
+        std::string outfile = "WorkshopModsEnabled=";
+        for (std::string s : Settings::WorkshopModsEnabled)
+            outfile += s + ",";
+        outfile += "\nCustomModsEnabled=";
+        for (std::string s : Settings::CustomModsEnabled)
+            outfile += Utils::Replace(s, Filesystem::ArmaDirMark, Settings::ArmaPath) + ",";
+
+        path = fcDialog.get_filename();
+        Filesystem::WriteAllText(path, outfile);
+    }
+}
+
 bool MainWindow::onExit(GdkEventAny *event)
 {
     LOG(1, "onExit() -> restoring Arma3.cfg");
@@ -412,6 +504,8 @@ void MainWindow::WorkshopToggleBox_Toggled(Glib::ustring path) //path is index n
     //std::cout << path << std::endl;
     Gtk::TreeModel::Row row = *(workshopModsStore.operator ->()->get_iter(path));
     row[workshopColumns.enabled] = !row[workshopColumns.enabled];
+    if (Settings::ModPreset[Settings::ModPreset.length() - 1] != '*')
+        Settings::ModPreset += "*";
     RefreshStatusLabel();
 }
 
@@ -420,6 +514,8 @@ void MainWindow::CustomToggleBox_Toggled(Glib::ustring path) //path is index num
     //std::cout << path << std::endl;
     Gtk::TreeModel::Row row = *(customModsStore.operator ->()->get_iter(path));
     row[customColumns.enabled] = !row[customColumns.enabled];
+    if (Settings::ModPreset[Settings::ModPreset.length() - 1] != '*')
+        Settings::ModPreset += "*";
     RefreshStatusLabel();
 }
 
@@ -764,7 +860,9 @@ void MainWindow::RefreshStatusLabel()
     lblSelectedMods->set_text("Selected " + std::to_string(workshopMods + customMods)
                               + " mods (" + std::to_string(workshopMods)
                               + " from workshop, " + std::to_string(customMods)
-                              + " custom)");
+                              + " custom)"
+                              + "\t"
+                              + "Mod Preset: " + Settings::ModPreset);
 }
 
 void MainWindow::Init()

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -27,6 +27,9 @@ class MainWindow : public Gtk::Window
         Gtk::Button *btnAdd;
         Gtk::Button *btnRemove;
 
+        Gtk::Button *btnPresetLoad;
+        Gtk::Button *btnPresetSave;
+
         Glib::RefPtr<Gtk::CellRendererToggle> workshopToggleBox;
         Glib::RefPtr<Gtk::CellRendererToggle> customToggleBox;
 
@@ -134,6 +137,9 @@ class MainWindow : public Gtk::Window
 
         void btnAdd_Clicked();
         void btnRemove_Clicked();
+
+        void btnPresetLoad_Clicked();
+        void btnPresetSave_Clicked();
 
         bool onExit(GdkEventAny *event);
         void WorkshopToggleBox_Toggled(Glib::ustring path);

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -71,6 +71,8 @@ namespace Settings
 
     bool Host = false;
 
+    string ModPreset = "default";
+
     std::vector<std::string> WorkshopModsEnabled;
     std::vector<std::string> WorkshopModsOrder;
 
@@ -165,6 +167,8 @@ namespace Settings
                     PasswordValue = line.substr(14);
                 else if (Utils::StartsWith(line, "Host="))
                     Host = strtol(line.substr(5).c_str(), NULL, 10);
+                else if (Utils::StartsWith(line, "ModPreset="))
+                    ModPreset = line.substr(10);
                 else if (Utils::StartsWith(line, "WorkshopModsEnabled="))
                 {
                     string sub = line.substr(20);
@@ -239,6 +243,7 @@ namespace Settings
                          + "\nPassword=" + Utils::ToString(Password)
                          + "\nPasswordValue=" + PasswordValue
                          + "\nHost=" + Utils::ToString(Host)
+                         + "\nModPreset=" + (ModPreset[ ModPreset.length() - 1 ] == '*' ? "default" : ModPreset)
                          + "\nWorkshopModsEnabled=";
 
 

--- a/Settings.h
+++ b/Settings.h
@@ -66,6 +66,8 @@ namespace Settings
 
     extern bool Host;
 
+    extern std::string ModPreset;
+
     extern std::vector<std::string> WorkshopModsEnabled;
     extern std::vector<std::string> WorkshopModsOrder;
 


### PR DESCRIPTION
This allows the user to save any mod configuration to a file and later load that mod configuration from this file.
Saves CustomModsEnabled and WorkshopModsEnabled like in the settings.conf, but to a user-specified file. 
By default the last selected Mod Preset is loaded.
CustomModsEnabled and WorkshopModsEnabled are still saved to settings.conf so that when a mod preset is loaded, edited, but not saved, the edits will still be loaded next startup.
If a mod is removed that is still present in a modpreset file, it will simply not be loaded. It won't be removed from the preset.

I haven't run into any problems with it, but should a bug be found, I will maintain this feature.