### PR TITLE
bunch of fixes for Proton

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -317,6 +317,8 @@ void MainWindow::ArmaStatusThread()
         armaPid = Utils::FindProcess("ArmA3");
         #else
         armaPid = Utils::FindProcess("./arma3.x86_64");
+        if (armaPid == -1)
+            armaPid = Utils::FindProcess("Arma3_x64.exe");
         #endif
         this->notify();
         std::this_thread::sleep_for(std::chrono::seconds(2));
@@ -879,7 +881,10 @@ void MainWindow::btnPlay_Clicked()
     #ifdef __APPLE__
     Glib::spawn_command_line_async("open steam://run/107410//" + Utils::Replace(parameters, " ", "%20"));
     #else
-    Glib::spawn_command_line_async("steam -applaunch 107410 " + parameters);
+    if (Filesystem::IsProton(Settings::ArmaPath))
+        Glib::spawn_command_line_async("steam -applaunch 107410 -nolauncher " + parameters);
+    else
+        Glib::spawn_command_line_async("steam -applaunch 107410 " + parameters);
     #endif
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -183,43 +183,16 @@ int main(int argc, char *argv[])
 
     if (Filesystem::IsProton(Settings::ArmaPath))
     {
-        string arma3_launcher_path = Settings::ArmaPath + "/arma3launcher.exe";
-        struct stat st;
-
-        auto do_link = [&]()
-        {
-            int result = symlink((Settings::ArmaPath + "/arma3_x64.exe").c_str(), arma3_launcher_path.c_str());
-            if (result == 0)
-                LOG(0, "Successfully created symlink");
-            return result;
-        };
-
-        int return_code = stat(arma3_launcher_path.c_str(), &st);
-        if (return_code != 0)
-        {
-            LOG(0, arma3_launcher_path + " does not exist, linking to arma3_x64.exe");
-            do_link();
-        }
-        else if (return_code == 0)
-        {
-            int minimal_binary_size = 10 * 1024 * 1024;
-            if (st.st_size < minimal_binary_size)
-            {
-                LOG(0, "Original launcher detected, moving to /arma3launcher.exe.backup");
-                rename(arma3_launcher_path.c_str(), (arma3_launcher_path + ".backup").c_str());
-                do_link();
-            }
-            else
-                LOG(0, "/arma3launcher.exe looks ok");
-        }
-
         Filesystem::ArmaConfigFile = Settings::ArmaPath + "/../../compatdata/107410/pfx/drive_c/users/steamuser/My Documents/Arma 3/Arma3.cfg";
         LOG(0, "Proton detected");
 
         LOG(1, "Config path: " + Filesystem::ArmaConfigFile);
         if (!Filesystem::FileExists(Filesystem::ArmaConfigFile))
         {
-            LOG(1, "Arma3.cfg does not exist\nPlease run Arma at least once before using launcher. You can start it from Steam (original launcher has been replaced)");
+            std::string no_cfg_msg = "Arma3.cfg does not exist\nPlease run Arma at least once before using launcher. You can start it from Steam (add -nolauncher parameter)";
+            Gtk::MessageDialog no_cfg_dialog(no_cfg_msg);
+            no_cfg_dialog.run();
+            LOG(1, no_cfg_msg);
             exit(1);
         }
 


### PR DESCRIPTION
do not move exe files when using Proton, use '-nolauncher' instead
better exit message when Arma3.cfg is not found