### PR TITLE
Make doctest catch exceptions

### DIFF
--- a/src/arma3-unix-launcher-library/arma3client.cpp
+++ b/src/arma3-unix-launcher-library/arma3client.cpp
@@ -282,7 +282,7 @@ class ARMA3ClientFixture : public Tests::Fixture
             std::filesystem::create_directory(client_tests_dir);
         }
 
-        ~ARMA3ClientFixture()
+        ~ARMA3ClientFixture() noexcept(false)
         {
             std::filesystem::remove_all(client_tests_dir);
         }


### PR DESCRIPTION
Otherwise, in case of OS errors there would be a call to std::terminate().