### PR TITLE
Fixes for mod directory parsing

### DIFF
--- a/Filesystem.cpp
+++ b/Filesystem.cpp
@@ -411,7 +411,10 @@ namespace Filesystem
             else
                 fullPath += Filesystem::ArmaDirWorkshop;
             fullPath += "/" + symlinkAt + modList[i]->DirName;
-
+            string testPath = GetSymlinkTarget(fullPath);
+            if (testPath != NOT_A_SYMLINK) {
+                fullPath = testPath;
+            };
             string dirName = symlinkAt + modList[i]->DirName;
 
             string disk = "C:";

--- a/Mod.cpp
+++ b/Mod.cpp
@@ -13,6 +13,7 @@
 
 #include "Utils.h"
 #include "Filesystem.h"
+#include "Settings.h"
 #include "Logger.h"
 
 using namespace std;
@@ -37,7 +38,7 @@ Mod::Mod(string path, string workshopId)
         metaPath = "";
     if (!Filesystem::FileExists(modPath))
         modPath = "";
-    ParseCPP(metaPath, modPath);
+    ParseCPP(metaPath, modPath,path,workshopId);
 
     //Mod is added manually by user and din't contain any data in meta.cpp or mod.cpp
     //quick & dirty -> Name = DirectoryName
@@ -69,7 +70,7 @@ string Mod::ParseString(string input)
 }
 
 //As anyone would expect - documentation on this is trash
-void Mod::ParseCPP(string meta, string mod)
+void Mod::ParseCPP(string meta, string mod, string path,string workshopId)
 {
     if (meta != "")
     {
@@ -177,6 +178,9 @@ void Mod::ParseCPP(string meta, string mod)
             }
         }
     }
+    if (workshopId == "-1") {
+        this->DirName = Utils::Replace(path, Settings::ArmaPath+"/", "");
+    };
     if (this->DirName.empty())
     {
         this->DirName = this->Name;

--- a/Mod.h
+++ b/Mod.h
@@ -33,7 +33,7 @@ class Mod
         bool Enabled;
 
     private:
-        void ParseCPP(std::string meta, std::string mod);
+        void ParseCPP(std::string meta, std::string mod, std::string path, std::string workshopId);
         std::string ParseString(std::string input);
 };
 


### PR DESCRIPTION
Implement nPHYN1T3's fix
Fix custom mods to use the actual directory they're in instead of the mod.cpp name