### PR TITLE
Limit mod list in preset import dialog

### DIFF
--- a/src/arma3-unix-launcher/mainwindow.cpp
+++ b/src/arma3-unix-launcher/mainwindow.cpp
@@ -694,7 +694,8 @@ void MainWindow::load_mods_from_html(std::string const &path)
         return;
 
     std::string mod_list;
-    int mod_count, mod_count_overload;
+    int mod_count = 0;
+    int mod_count_overload = 0;
     for (auto const &json_mod : not_existing_mods)
     {
         if (mod_count >= 25)

--- a/src/arma3-unix-launcher/mainwindow.cpp
+++ b/src/arma3-unix-launcher/mainwindow.cpp
@@ -694,8 +694,25 @@ void MainWindow::load_mods_from_html(std::string const &path)
         return;
 
     std::string mod_list;
+    int mod_count, mod_count_overload;
     for (auto const &json_mod : not_existing_mods)
-        mod_list += fmt::format("{}\n", std::string(json_mod["displayName"]));
+    {
+        if (mod_count >= 25)
+        {
+            mod_count_overload++;
+        }
+        else
+        {
+            mod_list += fmt::format("{}\n", std::string(json_mod["displayName"]));
+            mod_count++;
+        }
+    }
+
+    if (mod_count >= 25)
+    {
+        mod_list += fmt::format("and {} more...\n", std::to_string(mod_count_overload));
+    }
+
 
     if (steam_integration->is_initialized())
     {

--- a/src/steam-integration/steam_integration.cpp
+++ b/src/steam-integration/steam_integration.cpp
@@ -35,7 +35,7 @@ namespace
 
         auto old_path = fs::CurrentPath();
         auto tmp_path = fs::TempDirectoryPath() / "arma3-unix-launcher.tmp";
-        TODO_BEFORE(05, 2020, "Better temporary path - this will break with 2 processes");
+        TODO_BEFORE(06, 2020, "Better temporary path - this will break with 2 processes");
         fs::CreateDirectories(tmp_path);
         fs::CurrentPath(tmp_path);
         StdUtils::FileWriteAllText(tmp_path / "steam_appid.txt", app_id);


### PR DESCRIPTION
When importing a preset with too many missing mods, the dialog fills up and goes off the screen, as shown in image below. 
![image](https://user-images.githubusercontent.com/43392677/81063376-f2bff280-8ed7-11ea-94e5-b2b23af03c72.png)

This PR limits the amount of mod names that can be displayed so that does not happen. 
