### PR TITLE
cmake: switch to fmt-header-only

### DIFF
--- a/cmake/external_dependencies.cmake
+++ b/cmake/external_dependencies.cmake
@@ -78,12 +78,7 @@ function(setup_fmt)
     setup_library("${CHECK_SOURCE}"
                   NAME fmt
                   GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-                  TEST_LINK_LIBS fmt
                   )
-    get_target_property(TARGET_TYPE fmt::fmt TYPE)
-    if ("${TARGET_TYPE}" STREQUAL "SHARED_LIBRARY")
-        target_compile_options(fmt::fmt INTERFACE "-fpic")
-    endif()
 endfunction()
 
 function(setup_nlohmann_json)

--- a/src/arma3-unix-launcher-library/CMakeLists.txt
+++ b/src/arma3-unix-launcher-library/CMakeLists.txt
@@ -2,4 +2,4 @@ file(GLOB_RECURSE SOURCES *.cpp *.hpp)
 
 add_library(arma3-unix-launcher-library STATIC ${SOURCES})
 target_include_directories(arma3-unix-launcher-library INTERFACE .)
-target_link_libraries(arma3-unix-launcher-library PRIVATE common fmt::fmt nlohmann::json)
+target_link_libraries(arma3-unix-launcher-library PRIVATE common fmt::fmt-header-only nlohmann::json)

--- a/src/arma3-unix-launcher/CMakeLists.txt
+++ b/src/arma3-unix-launcher/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(arma3-unix-launcher PRIVATE
     common
     steam-integration
     argparse::argparse
-    fmt::fmt
+    fmt::fmt-header-only
     nlohmann::json
     pugixml::pugixml
     Qt5::Widgets

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -2,4 +2,4 @@ file(GLOB_RECURSE SOURCES *.cpp *.hpp)
 
 add_library(common STATIC ${SOURCES})
 target_include_directories(common INTERFACE .)
-target_link_libraries(common PRIVATE fmt::fmt)
+target_link_libraries(common PRIVATE fmt::fmt-header-only)

--- a/src/steam-integration/CMakeLists.txt
+++ b/src/steam-integration/CMakeLists.txt
@@ -17,7 +17,7 @@ target_include_directories(steam-integration INTERFACE .)
 
 if (STEAMWORKS_SDK_DETECTED)
     target_sources(steam-integration PRIVATE ${SOURCES})
-    target_link_libraries(steam-integration PRIVATE common fmt::fmt steamworks::sdk)
+    target_link_libraries(steam-integration PRIVATE common fmt::fmt-header-only steamworks::sdk)
 else()
     target_sources(steam-integration PRIVATE ${SOURCES_STUB})
 endif()

--- a/tests/unit/arma3-unix-launcher-library/CMakeLists.txt
+++ b/tests/unit/arma3-unix-launcher-library/CMakeLists.txt
@@ -19,7 +19,7 @@ create_unit_test(TEST_GROUP library
                             ${CMAKE_SOURCE_DIR}/tests/unit/mock/vdf.hpp
                  INCLUDES   ${CMAKE_SOURCE_DIR}/src/arma3-unix-launcher-library
                             ${CMAKE_SOURCE_DIR}/src/common
-                 LINK_LIBS  fmt::fmt
+                 LINK_LIBS  fmt::fmt-header-only
                  )
 
 create_unit_test(TEST_GROUP library
@@ -33,7 +33,7 @@ create_unit_test(TEST_GROUP library
                             ${CMAKE_SOURCE_DIR}/tests/unit/default_test_reporter.hpp
                  INCLUDES   ${CMAKE_SOURCE_DIR}/src/arma3-unix-launcher-library
                             ${CMAKE_SOURCE_DIR}/src/common
-                 LINK_LIBS  fmt::fmt
+                 LINK_LIBS  fmt::fmt-header-only
                  )
 
 create_unit_test(TEST_GROUP library
@@ -53,7 +53,7 @@ create_unit_test(TEST_GROUP library
                             ${CMAKE_SOURCE_DIR}/tests/unit/mock/vdf.hpp
                  INCLUDES   ${CMAKE_SOURCE_DIR}/src/arma3-unix-launcher-library
                             ${CMAKE_SOURCE_DIR}/src/common
-                 LINK_LIBS  fmt::fmt
+                 LINK_LIBS  fmt::fmt-header-only
                  )
 
 create_unit_test(TEST_GROUP library
@@ -77,7 +77,7 @@ create_unit_test(TEST_GROUP library
                             ${CMAKE_SOURCE_DIR}/tests/unit/mock/vdf.hpp
                  INCLUDES   ${CMAKE_SOURCE_DIR}/src/arma3-unix-launcher-library
                             ${CMAKE_SOURCE_DIR}/src/common
-                 LINK_LIBS  fmt::fmt
+                 LINK_LIBS  fmt::fmt-header-only
                  )
 
 create_unit_test(TEST_GROUP library
@@ -91,5 +91,5 @@ create_unit_test(TEST_GROUP library
                             ${CMAKE_SOURCE_DIR}/tests/unit/default_test_reporter.hpp
                  INCLUDES   ${CMAKE_SOURCE_DIR}/src/arma3-unix-launcher-library
                             ${CMAKE_SOURCE_DIR}/src/common
-                 LINK_LIBS  fmt::fmt
+                 LINK_LIBS  fmt::fmt-header-only
                  )

--- a/tests/unit/common/CMakeLists.txt
+++ b/tests/unit/common/CMakeLists.txt
@@ -10,7 +10,7 @@ create_unit_test(TEST_GROUP common
 
                             ${CMAKE_SOURCE_DIR}/tests/unit/default_test_reporter.hpp
                  INCLUDES   ${CMAKE_SOURCE_DIR}/src/common
-                 LINK_LIBS  fmt::fmt
+                 LINK_LIBS  fmt::fmt-header-only
                  )
 
 create_unit_test(TEST_GROUP common
@@ -21,5 +21,5 @@ create_unit_test(TEST_GROUP common
 
                             ${CMAKE_SOURCE_DIR}/tests/unit/default_test_reporter.hpp
                  INCLUDES   ${CMAKE_SOURCE_DIR}/src/common
-                 LINK_LIBS  fmt::fmt
+                 LINK_LIBS  fmt::fmt-header-only
                  )


### PR DESCRIPTION
fixes issues when library mismatch could appear

fixes #121 