### PR TITLE
packaging: ubuntu: fix deb package version

### DIFF
--- a/tools/ci/packaging/ubuntu-16.04/build.sh
+++ b/tools/ci/packaging/ubuntu-16.04/build.sh
@@ -25,7 +25,7 @@ popd
 PKG_DIR="$BUILD_DIR/arma3-unix-launcher-$COMMIT_COUNT.$SHORT_HASH-$ID-$VERSION_ID-amd64"
 mkdir -p $PKG_DIR/DEBIAN
 
-sed "s/VERSION/$COMMIT_COUNT-$SHORT_HASH/g" ./control >$PKG_DIR/DEBIAN/control
+sed "s/VERSION/$COMMIT_COUNT.$SHORT_HASH/g" ./control >$PKG_DIR/DEBIAN/control
 
 mkdir -p $BUILD_DIR
 pushd $BUILD_DIR

--- a/tools/ci/packaging/ubuntu-16.04/control
+++ b/tools/ci/packaging/ubuntu-16.04/control
@@ -1,5 +1,5 @@
 Package: arma3-unix-launcher
-Version: 0.1
+Version: VERSION
 Architecture: amd64
 Maintainer: muttleyxd <mateusz@szychowski.it>
 Depends:

--- a/tools/ci/packaging/ubuntu-18.04/build.sh
+++ b/tools/ci/packaging/ubuntu-18.04/build.sh
@@ -25,7 +25,7 @@ popd
 PKG_DIR="$BUILD_DIR/arma3-unix-launcher-$COMMIT_COUNT.$SHORT_HASH-$ID-$VERSION_ID-amd64"
 mkdir -p $PKG_DIR/DEBIAN
 
-sed "s/VERSION/$COMMIT_COUNT-$SHORT_HASH/g" ./control >$PKG_DIR/DEBIAN/control
+sed "s/VERSION/$COMMIT_COUNT.$SHORT_HASH/g" ./control >$PKG_DIR/DEBIAN/control
 
 mkdir -p $BUILD_DIR
 pushd $BUILD_DIR

--- a/tools/ci/packaging/ubuntu-18.04/control
+++ b/tools/ci/packaging/ubuntu-18.04/control
@@ -1,5 +1,5 @@
 Package: arma3-unix-launcher
-Version: 0.1
+Version: VERSION
 Architecture: amd64
 Maintainer: muttleyxd <mateusz@szychowski.it>
 Depends: libqt5widgets5, libqt5svg5


### PR DESCRIPTION
this fixes an issue where you couldn't upgrade to new launcher, because dpkg would reject as it always was the same version