### PR TITLE
launcher: fix path chooser dialog appearing as one pixel line

### DIFF
--- a/src/arma3-unix-launcher/arma_path_chooser_dialog.cpp
+++ b/src/arma3-unix-launcher/arma_path_chooser_dialog.cpp
@@ -22,7 +22,7 @@ ArmaPathChooserDialog::ArmaPathChooserDialog(QWidget *parent) :
     ui->horizontalLayout->setAlignment(Qt::AlignBottom);
     ui->verticalLayout->setAlignment(Qt::AlignTop);
 
-    this->setMaximumSize(1024000, 1);
+    this->setMaximumSize(1024000, 0);
     #ifndef __APPLE__
     this->setMinimumSize(450, 106);
     #endif


### PR DESCRIPTION
partly fixes #135