### PR TITLE
Add SOG Prairie Fire DLC in parameters & exclude DLC from mods list

### DIFF
--- a/src/arma3-unix-launcher-library/arma3client.hpp
+++ b/src/arma3-unix-launcher-library/arma3client.hpp
@@ -14,7 +14,7 @@ namespace ARMA3::Definitions
 
     static constexpr char const *app_id = "107410";
 
-    static const std::array<char const *, 24> exclusions{"Addons", "AoW", "Argo", "BattlEye", "Contact", "Curator", "Dll", "Dta", "Enoch", "Expansion", "fontconfig", "Heli", "Jets", "Kart", "Keys", "Launcher", "MPMissions", "Mark", "Missions", "Orange", "Tacops", "Tank", "legal", "steam_shader_cache"};
+    static const std::array<char const *, 26> exclusions{"Addons", "AoW", "Argo", "BattlEye", "Contact", "Curator", "Dll", "Dta", "Enoch", "Expansion", "fontconfig", "GM", "Heli", "Jets", "Kart", "Keys", "Launcher", "MPMissions", "Mark", "Missions", "Orange", "Tacops", "Tank", "vn", "legal", "steam_shader_cache"};
     TODO_BEFORE(06, 2021, "Use dta/product.bin for exclusion list");
 
     #ifdef __linux

--- a/src/arma3-unix-launcher/mainwindow.cpp
+++ b/src/arma3-unix-launcher/mainwindow.cpp
@@ -154,6 +154,8 @@ try
         mods.push_back(client->GetPath() / "Contact");
     if (parameters["dlcGlobalMobilization"])
         mods.push_back(client->GetPath() / "GM");
+    if(parameters["dlcSogPrairieFire"])
+        mods.push_back(client->GetPath() / "vn");
     if (!parameters["environmentVariables"].is_null())
         environment_variables = parameters["environmentVariables"];
 

--- a/src/arma3-unix-launcher/mainwindow.ui
+++ b/src/arma3-unix-launcher/mainwindow.ui
@@ -243,6 +243,13 @@
                  </widget>
                 </item>
                 <item>
+                 <widget class="QCheckBox" name="checkbox_dlc_sog_prairie_fire">
+                  <property name="text">
+                   <string>Enable S.O.G. Prairie Fire DLC</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
                  <widget class="QCheckBox" name="checkbox_disable_esync">
                   <property name="text">
                    <string>Proton: Disable esync</string>

--- a/src/arma3-unix-launcher/settings.cpp
+++ b/src/arma3-unix-launcher/settings.cpp
@@ -27,6 +27,7 @@ namespace
                                                             "customParameters": null,
                                                             "dlcContact": false,
                                                             "dlcGlobalMobilization": false,
+                                                            "dlcSogPrairieFire": false,
                                                             "enableHT": false,
                                                             "environmentVariables": null,
                                                             "exThreads": -1,
@@ -125,6 +126,7 @@ void Settings::load_settings_to_ui(Ui::MainWindow *ui)
     read_setting("name", ui->checkbox_profile, ui->textbox_profile);
     read_setting("dlcContact", ui->checkbox_dlc_contact);
     read_setting("dlcGlobalMobilization", ui->checkbox_dlc_global_mobilization);
+    read_setting("dlcSogPrairieFire", ui->checkbox_dlc_sog_prairie_fire);
     read_setting("protonDisableEsync", ui->checkbox_disable_esync);
 
     // advanced tab
@@ -203,6 +205,7 @@ void Settings::save_settings_from_ui(Ui::MainWindow *ui)
     write_setting("name", ui->checkbox_profile, ui->textbox_profile);
     write_setting("dlcContact", ui->checkbox_dlc_contact);
     write_setting("dlcGlobalMobilization", ui->checkbox_dlc_global_mobilization);
+    write_setting("dlcSogPrairieFire", ui->checkbox_dlc_sog_prairie_fire);
     write_setting("protonDisableEsync", ui->checkbox_disable_esync);
 
     // advanced tab


### PR DESCRIPTION
Adds "GM" and "vn" to exclusion list, so DLC stop showing up in the mods list.  
Adds SOG Praririe Fire (vn) CDLC to parameter list, just like GM and Contact.