### PR TITLE
Make Mods Table Sortable

### DIFF
--- a/src/arma3-unix-launcher/modtablewidget.cpp
+++ b/src/arma3-unix-launcher/modtablewidget.cpp
@@ -1,4 +1,5 @@
 #include "modtablewidget.h"
+#include "tablewidgetcheckboxitem.h"
 
 #include <algorithm>
 #include <set>
@@ -19,6 +20,8 @@ namespace
         w.viewport()->setAcceptDrops(true);
         w.setDragDropOverwriteMode(false);
         w.setDropIndicatorShown(true);
+
+        w.setSortingEnabled(true);
 
         w.setSelectionMode(QAbstractItemView::ExtendedSelection);
         w.setSelectionBehavior(QAbstractItemView::SelectRows);
@@ -146,11 +149,21 @@ void ModTableWidget::add_mod(UiMod const &mod, int index)
         checkbox->setCheckState(Qt::Unchecked);
 
     setCellWidget(index, 0, checkbox_widget);
+
+    //kinda hacky, but least code changes... (this is a hidden item)
+    auto checkbox_sort = new TableWidgetCheckboxItem(mod.enabled);
+    setItem(index, 0, checkbox_sort);
+
     setItem(index, 1, new QTableWidgetItem(mod.name.c_str()));
     setItem(index, 2, new QTableWidgetItem(mod.path_or_workshop_id.c_str()));
     setItem(index, 3, new QTableWidgetItem(mod.is_workshop_mod_to_string()));
 
     QObject::connect(checkbox, &QCheckBox::stateChanged, this, &ModTableWidget::update_mod_selection_counters);
+
+    //kinda hacky again, but QTableWidgetItem isn't a QObject, so we cannot connect to it
+    QObject::connect(checkbox, &QCheckBox::stateChanged, this, [=](int c){
+        checkbox_sort->setModEnabled(c);
+    });
 
     for (int i = 1; i < columnCount(); ++i)
     {

--- a/src/arma3-unix-launcher/tablewidgetcheckboxitem.cpp
+++ b/src/arma3-unix-launcher/tablewidgetcheckboxitem.cpp
@@ -1,0 +1,6 @@
+#include "tablewidgetcheckboxitem.h"
+
+TableWidgetCheckboxItem::TableWidgetCheckboxItem(bool enabled)
+{
+    setData(Qt::UserRole, enabled);
+}

--- a/src/arma3-unix-launcher/tablewidgetcheckboxitem.h
+++ b/src/arma3-unix-launcher/tablewidgetcheckboxitem.h
@@ -1,0 +1,22 @@
+#ifndef TABLEWIDGETCHECKBOXITEM_H
+#define TABLEWIDGETCHECKBOXITEM_H
+
+#include <QTableWidgetItem>
+
+class TableWidgetCheckboxItem : public QTableWidgetItem
+{
+public:
+    explicit TableWidgetCheckboxItem(bool enabled);
+
+    virtual bool operator<(const QTableWidgetItem& other) const override {
+        bool selfEnabled = data(Qt::UserRole).toBool();
+        bool otherEnabled = other.data(Qt::UserRole).toBool();
+        return selfEnabled < otherEnabled;
+    }
+
+    void setModEnabled(int checkstate) {
+        setData(Qt::UserRole, checkstate == Qt::Checked ? true : false);
+    }
+};
+
+#endif // TABLEWIDGETCHECKBOXITEM_H


### PR DESCRIPTION
Enables sorting on the mods table columns.

Had to introduce a little hacky solution for sorting the checkbox column, but I wanted to keep the code changes minimal.  
Basically we insert a normal QTableWidgetItem, which has no data and is thus hidden, and the checkbox widget is drawn on top. So everything looks like it did before.  
But this Item has a boolean member which is synchronized (with QObject::connect) to the Checkbox, and is used to sort the column by overriding `operator<`