### PR TITLE
Small build typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Requirements:
 
 After that you can launch with
 
-    ./src/arma3-unix-launcher
+    ./src/arma3-unix-launcher/arma3-unix-launcher
 
 ### Launch parameters
 


### PR DESCRIPTION
`./src/arma3-unix-launcher/` is a directory that the build creates
`./src/arma3-unix-launcher/arma3-unix-launcher` is the binary you want to run.