### PR TITLE
library: html_preset_export: fix ampersand in mod name for Windows launcher compatibility

### DIFF
--- a/src/arma3-unix-launcher-library/html_preset_export.cpp
+++ b/src/arma3-unix-launcher-library/html_preset_export.cpp
@@ -118,10 +118,11 @@ std::string export_mods(std::string_view preset_name, std::vector<Mod> const& mo
 
     std::string mod_list = "";
     for (auto const& mod: mods) {
+        auto mod_name = StringUtils::Replace(mod.GetName(), "&", "&amp;");
         if (mod.IsWorkshopMod(workshop_path))
-            mod_list += fmt::format(STEAM_MOD_TEMPLATE, "mod_name"_a=mod.GetName(), "workshop_id"_a=mod.path_.filename().string());
+            mod_list += fmt::format(STEAM_MOD_TEMPLATE, "mod_name"_a=mod_name, "workshop_id"_a=mod.path_.filename().string());
         else
-            mod_list += fmt::format(LOCAL_MOD_TEMPLATE, "mod_name"_a=mod.GetName(), "mod_dir"_a=mod.path_.filename().string(), "mod_link"_a=mod.GetValueOrReturnDefault("url", "action", "https://github.com/muttleyxd/arma3-unix-launcher"));
+            mod_list += fmt::format(LOCAL_MOD_TEMPLATE, "mod_name"_a=mod_name, "mod_dir"_a=mod.path_.filename().string(), "mod_link"_a=mod.GetValueOrReturnDefault("url", "action", "https://github.com/muttleyxd/arma3-unix-launcher"));
     }
     return fmt::format(PRESET_TEMPLATE, "mod_list"_a=StringUtils::trim_right(mod_list), "preset_name"_a=preset_name);
 }

--- a/tests/unit/arma3-unix-launcher-library/CMakeLists.txt
+++ b/tests/unit/arma3-unix-launcher-library/CMakeLists.txt
@@ -42,6 +42,9 @@ create_unit_test(TEST_GROUP library
                              ${CMAKE_SOURCE_DIR}/src/arma3-unix-launcher-library/html_preset_export.cpp
                              ${CMAKE_SOURCE_DIR}/src/arma3-unix-launcher-library/html_preset_export.hpp
 
+                             ${CMAKE_SOURCE_DIR}/src/common/string_utils.cpp
+                             ${CMAKE_SOURCE_DIR}/src/common/string_utils.hpp
+
                              ${CMAKE_SOURCE_DIR}/tests/unit/default_test_reporter.hpp
                   INCLUDES   ${CMAKE_SOURCE_DIR}/src/arma3-unix-launcher-library
                              ${CMAKE_SOURCE_DIR}/src/common

--- a/tests/unit/arma3-unix-launcher-library/test_html_preset_export.cpp
+++ b/tests/unit/arma3-unix-launcher-library/test_html_preset_export.cpp
@@ -93,7 +93,7 @@ a:hover {
     <div class="mod-list">
       <table>
         <tr data-type="ModContainer">
-          <td data-type="DisplayName">1234 mod</td>
+          <td data-type="DisplayName">1234 mod &amp; special character</td>
           <td>
             <span class="from-steam">Steam</span>
           </td>
@@ -122,7 +122,7 @@ a:hover {
     };
 
     REQUIRE_CALL(mod_mock, IsWorkshopMod(workshop_path, _)).RETURN(true);
-    REQUIRE_CALL(mod_mock, GetName(_)).RETURN("1234 mod");
+    REQUIRE_CALL(mod_mock, GetName(_)).RETURN("1234 mod & special character");
     auto const preset = export_mods("test preset", mod_list, workshop_path);
     CHECK_EQ(expected_preset, preset);
 }


### PR DESCRIPTION
fixes #217 