### PR TITLE
Update ubuntu apt install in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Requirements:
 
 #### Debian-based (Debian, Ubuntu)
     apt install cmake qt5-default libqt5widgets5 libqt5svg5 libqt5svg5-dev libfmt-dev libspdlog-dev
+    
+Package qt5-default is not available?
+    apt install cmake qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5widgets5 libqt5svg5 libqt5svg5-dev libfmt-dev libspdlog-dev
 
 #### Arch-based (Arch Linux, Manjaro)
     pacman -S cmake fmt nlohmann-json pugixml qt5-base qt5-svg spdlog


### PR DESCRIPTION
Added an alternative if qt5-default is not available.
For me on the latest Pop!_OS 22.04 LTS qt5-default was not available.

Found this solution at https://askubuntu.com/a/1335187