### PR TITLE
Fix for string type errors

### DIFF
--- a/src/steam-integration/steam_integration_impl.hpp
+++ b/src/steam-integration/steam_integration_impl.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "steam_integration_stub.hpp"
+#include <string>
 
 namespace Steam
 {

--- a/src/steam-integration/steam_integration_stub.cpp
+++ b/src/steam-integration/steam_integration_stub.cpp
@@ -1,4 +1,5 @@
 #include "steam_integration_stub.hpp"
+#include <string>
 
 class CallbackCatcher
 {


### PR DESCRIPTION
Fix for #193 and #234

Occasionally, the AUR packages for arma 3 unix launcher fail to launch due to new updates to Arch libs. The latest error returned when running the launcher is 
```
arma3-unix-launcher: symbol lookup error: arma3-unix-launcher: undefined symbol: _ZN6spdlog7details7log_msgC1ENS_10source_locEN3fmt2v817basic_string_viewIcEENS_5level10level_enumES6_
```

This can be fixed by installing the launcher from source. However, more issues crop up related to incorrect string types. This PR fixes the issue with building the launcher on Arch.

According to the advice of @muttleyxd, adding `#include <string>` to the tops of `steam_integration_impl.hpp` and `steam_integration_stub.cpp` would prevent errors during build. I can confirm in my testing that fixes the build and, consequently, the launcher.

In this PR is to merge the changes to the master repository. I would appreciate a review.