### PR TITLE
Add context menu to enable all mods

### DIFF
--- a/src/arma3-unix-launcher/mainwindow.cpp
+++ b/src/arma3-unix-launcher/mainwindow.cpp
@@ -146,6 +146,11 @@ If there is an update, then you will get a notification, nothing will be downloa
     if (steam_integration->is_initialized())
         setup_steam_integration();
 
+    ui->table_mods->addAction(ui->action_mods_enable_all);
+    ui->table_mods->setContextMenuPolicy(Qt::ContextMenuPolicy::ActionsContextMenu);
+    connect(ui->action_mods_enable_all, &QAction::triggered, this,
+            &MainWindow::on_mods_enable_all_mods);
+
     ui->table_mods->addAction(ui->action_mods_disable_all);
     ui->table_mods->setContextMenuPolicy(Qt::ContextMenuPolicy::ActionsContextMenu);
     connect(ui->action_mods_disable_all, &QAction::triggered, this,
@@ -945,6 +950,12 @@ catch (std::exception const &e)
 void MainWindow::on_mods_disable_all_mods()
 {
     ui->table_mods->disable_all_mods();
+    put_mods_from_ui_to_manager_settings();
+}
+
+void MainWindow::on_mods_enable_all_mods()
+{
+    ui->table_mods->enable_all_mods();
     put_mods_from_ui_to_manager_settings();
 }
 

--- a/src/arma3-unix-launcher/mainwindow.h
+++ b/src/arma3-unix-launcher/mainwindow.h
@@ -86,6 +86,7 @@ class MainWindow : public QMainWindow
         void on_workshop_mod_installed(Steam::Structs::ItemDownloadedInfo const &info);
 
         void on_mods_disable_all_mods();
+        void on_mods_enable_all_mods();
 
         void initialize_theme_combobox();
 

--- a/src/arma3-unix-launcher/mainwindow.ui
+++ b/src/arma3-unix-launcher/mainwindow.ui
@@ -658,6 +658,14 @@
     </item>
    </layout>
   </widget>
+  <action name="action_mods_enable_all">
+   <property name="text">
+    <string>Enable all mods</string>
+   </property>
+   <property name="toolTip">
+    <string>Enable all mods</string>
+   </property>
+  </action>
   <action name="action_mods_disable_all">
    <property name="text">
     <string>Disable all mods</string>

--- a/src/arma3-unix-launcher/modtablewidget.cpp
+++ b/src/arma3-unix-launcher/modtablewidget.cpp
@@ -195,6 +195,16 @@ void ModTableWidget::disable_all_mods()
     }
 }
 
+void ModTableWidget::enable_all_mods()
+{
+    for (int row = 0; row < rowCount(); ++row)
+    {
+        auto cell_widget = cellWidget(row, 0);
+        auto checkbox = cell_widget->findChild<QCheckBox *>();
+        checkbox->setCheckState(Qt::CheckState::Checked);
+    }
+}
+
 UiMod ModTableWidget::get_mod_at(int index) const
 {
     auto cell_widget = cellWidget(index, 0);

--- a/src/arma3-unix-launcher/modtablewidget.h
+++ b/src/arma3-unix-launcher/modtablewidget.h
@@ -19,6 +19,7 @@ class ModTableWidget : public QTableWidget
         void add_mod(UiMod const &mod, int index = -1);
         bool contains_mod(std::string_view const path_or_workshop_id) const;
         void disable_all_mods();
+        void enable_all_mods();
         UiMod get_mod_at(int index) const;
         std::vector<UiMod> get_mods() const;
 


### PR DESCRIPTION
There was already the possibility to easily disable all mods. Its counterpart, the option to enable all mods, was missing. By adding that it saves a lot of clicking in case most or all mods are to be enabled.