### PR TITLE
Configured the VDF parser to ignore whitespace instead of removing it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,24 @@ arma3-unix-launcher --preset-to-run testmod --server-ip 127.0.0.1 --server-port 
 
 <img src="https://i.imgur.com/t2HXjY5.png" width="400"><img src="https://i.imgur.com/sAetuqr.png" width="400">
 
+## Arma 3 Troubleshooting
+
+### Launch Issues
+When directly launching the game if you experience issues getting the game to start, such as a VDF error, a temporary solution can be to start the launcher with the `-d` or `--disable-steam-integration` flag.
+
+### Proton Custom Version (Compatability Tool Not Found)
+If using a custom verison of proton, like Glorious Eggroll or a source build, sometimes the launcher cannot find the implementation if its directory is different from what is written in the `config.vdf`. For example, if you're using Arch Linux's `proton-ge-custom-bin` it may install under `/usr/share/steam/compatibilitytools.d/proton-ge-custom`, but the CompatToolMapping for Arma in your `.steam/steam/config/config.vdf` may read as `Proton-GE`. To fix this, create a soft link to the actual installation, using the value in config.vdf as a link.
+
+If your custom tool is tn the user folder, assuming your custom build is in `proton-ge-custom/` but your config.vdf is pointing to `Proton-GE`:
+```shell
+ln -s [your/steam/path]/compatibilitytools.d/proton-ge-custom [your/steam/path]/compatibilitytools.d/Proton-GE
+```
+
+If your custom tool is in the system folder,assuming your custom build is in `proton-ge-custom/` but your config.vdf is pointing to `Proton-GE`:
+```shell
+sudo ln -s /usr/share/steam/compatibilitytools.d/proton-ge-custom /usr/share/steam/compatibilitytools.d/Proton-GE
+```
+
 ## DayZ Installation
 
 Before trying to run DayZ via Steam Proton, be sure to increase the max_map_count:

--- a/src/arma3-unix-launcher-library/vdf.cpp
+++ b/src/arma3-unix-launcher-library/vdf.cpp
@@ -21,7 +21,7 @@ void VDF::LoadFromText(std::string_view const text, bool append)
 {
     if (!append)
         KeyValue.clear();
-    ParseVDF(RemoveWhitespaces(text));
+    ParseVDF(std::string(text));
 }
 
 void VDF::AddKeyValuePair()
@@ -88,7 +88,9 @@ void VDF::ProcessChar(char c)
 
 void VDF::LookForKey(char c)
 {
-    if (c == '"')
+    if (std::isspace(c))
+        return;
+    else if (c == '"')
         state_ = VDFState::ReadingKey;
     else if (c == '}' && CanPop())
         hierarchy_.pop_back();
@@ -98,7 +100,9 @@ void VDF::LookForKey(char c)
 
 void VDF::LookForValue(char c)
 {
-    if (c == '"')
+    if (std::isspace(c))
+        return;
+    else if (c == '"')
         state_ = VDFState::ReadingValue;
     else if (c == '{')
     {


### PR DESCRIPTION
The `RemoveWhitespaces` function in `vdf.cpp` alternates to removing whitespace chars depending on whether or not its currently in a key or value. However, it does not check for escaped quotes, and this can cause the parser to fail to read. Since the parser makes better determinations of what is and is not a key or a value, the logic to ignore whitespace was moved directly into the parser itself. The RemoveWhitespace was taken off the LoadFromText function, since it would be going over the config.vdf twice.

Additionally, added some troubleshooting steps for Arma 3.

Fixes #284