### PR TITLE
Fix SIGABRT when loading config with custom mods

### DIFF
--- a/src/arma3-unix-launcher-library/mod.cpp
+++ b/src/arma3-unix-launcher-library/mod.cpp
@@ -73,9 +73,11 @@ void Mod::ParseCPP(std::string const &text)
 
             size_t value_start = split_place + 1;
             size_t value_end = line.length();
-            if (line.at(value_start) == '"') // Remove quotes
+            if (value_start >= value_end)
+                continue;
+            if (line[value_start] == '"') // Remove quotes
                 value_start++;
-            if (line.at(value_end - 1) == '"')
+            if (value_end > 0 && line[value_end - 1] == '"')
                 value_end--;
 
             std::string const key(StringUtils::trim(line.substr(0, split_place)));

--- a/src/arma3-unix-launcher/mainwindow.cpp
+++ b/src/arma3-unix-launcher/mainwindow.cpp
@@ -1009,14 +1009,9 @@ std::string MainWindow::full_path_to_ui_path(std::string ui_path) const
 }
 
 bool MainWindow::is_workshop_mod(std::string const &path_or_workshop_id)
-try
 {
-    // if path exists, then is absolute and certainly is not workshop id
-    return std::stoull(path_or_workshop_id) > 0;
-}
-catch (...)
-{
-    return false;
+    return !path_or_workshop_id.empty()
+           && std::all_of(path_or_workshop_id.begin(), path_or_workshop_id.end(), ::isdigit);
 }
 
 Mod MainWindow::get_mod(std::string const &path_or_workshop_id)

--- a/src/dayz-linux-launcher/mainwindow.cpp
+++ b/src/dayz-linux-launcher/mainwindow.cpp
@@ -958,14 +958,9 @@ std::string MainWindow::full_path_to_ui_path(std::string ui_path) const
 }
 
 bool MainWindow::is_workshop_mod(std::string const &path_or_workshop_id)
-try
 {
-    // if path exists, then is absolute and certainly is not workshop id
-    return std::stoull(path_or_workshop_id) > 0;
-}
-catch (...)
-{
-    return false;
+    return !path_or_workshop_id.empty()
+           && std::all_of(path_or_workshop_id.begin(), path_or_workshop_id.end(), ::isdigit);
 }
 
 Mod MainWindow::get_mod(std::string const &path_or_workshop_id)


### PR DESCRIPTION
The bundled libsteam_api.so exports its own `__cxa_throw`, which can break C++ exception propagation depending on the version shipped. This causes a SIGABRT on startup when the config contains custom (non-workshop) mods.

The crash path: `is_workshop_mod` calls `std::stoull` on a non-numeric path like `~arma/@mymod`, which throws `std::invalid_argument`. The exception goes through Steam's `__cxa_throw` instead of the system one, fails to unwind properly, and hits `std::terminate`.

Changes:
- Replace `std::stoull` + catch with `std::all_of(..., ::isdigit)` in `is_workshop_mod` (arma3 + dayz)
- Use bounds checks instead of `.at()` in `Mod::ParseCPP` to avoid `std::out_of_range` throws

Confirmed with `LD_PRELOAD=/usr/lib/libstdc++.so.6` — forcing the system `__cxa_throw` eliminates the crash, which validates the root cause.